### PR TITLE
Update pom.xml to Use Java 8 for Compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,15 @@
           </archive>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>8</source> <!-- Use 8 or later -->
+          <target>8</target> <!-- Use 8 or later -->
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Hello Sir,

I made a small change to the pom.xml file to fix a compilation error. The project was using an outdated Java version (5), which caused build failures. I added the Maven Compiler Plugin to explicitly set the Java version to 8. This resolved the compilation issues in my case and ensured compatibility with newer Java versions.

Thanks for reviewing.

Best,
Manya Agarwal